### PR TITLE
Add color cues for guessing cards

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -170,6 +170,17 @@ function createSVGElement(tagName) {
          while(this.el.firstChild){
             this.el.removeChild(this.el.firstChild);
          }
+         // update class based on current state
+         let cls = 'card';
+         if(this.masked){
+            if(this.userShape === null){
+               cls += ' masked';
+            }else{
+               cls += ' user-guess';
+            }
+         }
+         this.el.setAttribute('class', cls);
+
          createRectangle(this.el, this.size, this.size);
          createLine(this.el, -this.size/16, this.size/2, this.size/4, this.size/2);
          createLine(this.el, this.size / 2, -this.size/16, this.size / 2, this.size/4);

--- a/styles.css
+++ b/styles.css
@@ -36,6 +36,23 @@ body {
     ry : 10;
 }
 
+/* when a card is masked but not yet guessed */
+.card.masked .my-line {
+    stroke: rgb(180, 180, 180);
+}
+.card.masked .my-rect {
+    fill: rgb(240, 240, 240);
+    stroke: rgb(150, 150, 150);
+}
+
+/* when player has selected a shape for a masked card */
+.card.user-guess .my-line {
+    stroke: rgb(0, 123, 255);
+}
+.card.user-guess .my-rect {
+    stroke: rgb(0, 123, 255);
+}
+
 
 .array .my-rect {
     fill: rgba(0, 0, 255, 0);


### PR DESCRIPTION
## Summary
- style masked cards grey and guessed cards blue
- toggle card classes in `redraw` based on card state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687be196edf88327b8056b22c8a98e78